### PR TITLE
Upgrading AWS provider to 5.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_eip" "natgw" {
   count = var.natgw_enabled ? 1 : 0
 
   public_ipv4_pool = "amazon"
-  vpc = true
+  domain = "vpc"
 
   tags = {
     Name = format("eip-natgw-%s", local.my_vpc_name)

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.3"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4"
+      version = ">= 5.0"
     }
   }
 }


### PR DESCRIPTION
Changelog:

- Updating AWS provider version to ">= 5.0"
- Also updating `aws_eip` resource to support argument `domain = "vpc"`